### PR TITLE
채팅 초기화 및 채팅방 ID 관리 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 
-# Ignore application.properties file
-src/main/resources/application.properties
+# Ignore application.yml file
+src/main/resources/application.yml

--- a/front/src/index.js
+++ b/front/src/index.js
@@ -6,9 +6,7 @@ import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
     <App />
-  </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/front/src/pages/ChatPage.js
+++ b/front/src/pages/ChatPage.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, {useState, useEffect, useCallback} from 'react';
 import { useLocation } from 'react-router-dom';
 import styles from '../styles/ChatPage.module.css';
 import { ChatBox } from '../components';
-import { sendMessage } from '../services/sendMessage';
+import { sendMessage, initializeChat } from '../services/sendMessage';
 
 
 const ChatPage = () => {
@@ -13,19 +13,56 @@ const ChatPage = () => {
     const [messages, setMessages] = useState([]);
     const [currentStageIndex, setCurrentStageIndex] = useState(0);
     const [isActualMeeting, setIsActualMeeting] = useState(false);
+    const [chatRoomId, setChatRoomId] = useState(null);
+    const [isInitialized, setIsInitialized] = useState(false);
+
+
+    const initChat = useCallback(async () => {
+        if (isInitialized) return;
+
+        const newChatRoomId = Date.now();
+        setChatRoomId(newChatRoomId);
+
+        try {
+            console.log('Initializing chat with the following details:');
+            console.log('MBTI:', mbti);
+            console.log('ChatRoomId:', newChatRoomId);
+            console.log('Profile Details:', {
+                name, type, age, height, job, hobbies, tags, description
+            });
+
+            const data = await initializeChat(mbti, newChatRoomId);
+            console.log('Initialization response:', data);
+
+            if (data.claudeResponse) {
+                console.log('Claude\'s initial response:', data.claudeResponse);
+                setMessages(prevMessages => [...prevMessages, {
+                    content: data.claudeResponse.text,
+                    isSent: false,
+                    avatar: image,
+                }]);
+            }
+
+            setIsInitialized(true);
+        } catch (error) {
+            console.error('Error initializing chat:', error);
+        }
+    }, []);
+
+    useEffect(() => {
+        initChat();
+    }, [initChat]);
 
     useEffect(() => {
         console.log('ChatPage loaded with state:', location.state);
     }, [location.state]);
-
-
 
     const handleSendMessage = async (content) => {
         try {
             const newMessage = { content, isSent: true };
             setMessages(prevMessages => [...prevMessages, newMessage]);
 
-            const response = await sendMessage(content, mbti);
+            const response = await sendMessage(content, mbti, chatRoomId);
 
             if (response.claudeResponse && response.claudeResponse.text) {
                 const responseMessage = {
@@ -59,6 +96,7 @@ const ChatPage = () => {
                     profileDetails={{ image, name, type, age, height, job, hobbies, tags, description }}
                     messages={messages}
                     onSendMessage={handleSendMessage}
+                    chatRoomId={chatRoomId}
                 />
             </div>
         </main>

--- a/front/src/services/sendMessage.js
+++ b/front/src/services/sendMessage.js
@@ -2,14 +2,14 @@ import axios from "axios";
 
 const API_URL = 'http://localhost:8080';
 
-const sendMessage = async (message,mbti,context) => {
-    console.log("Send Message :"+message+"MBTI:"+mbti + "context :" + context)
+const sendMessage = async (message, mbti, chatRoomId) => {
+    console.log("Send Message :" + message + " MBTI:" + mbti + " ChatRoomId:" + chatRoomId)
     try {
         const response = await axios.post(`${API_URL}/api/ask-claude`,
             {
                 "message": message,
-                "mbti" : mbti,
-                "context": context
+                "mbti": mbti,
+                "chatRoomId": chatRoomId
             },
             {
                 headers: {
@@ -18,7 +18,7 @@ const sendMessage = async (message,mbti,context) => {
             }
         );
         console.log(response.data);
-        return response.data; // 이미 JSON 객체이므로 파싱할 필요 없음
+        return response.data;
     } catch (error) {
         console.error('Error sending message:', error);
         throw error;
@@ -56,9 +56,32 @@ const sendPostRequest = async (data, endpoint) => {
     }
 };
 
+const initializeChat = async (mbti, chatRoomId) => {
+    console.log("Initializing chat for MBTI:" + mbti + " ChatRoomId:" + chatRoomId)
+    try {
+        const response = await axios.post(`${API_URL}/api/initialize-chat`,
+            {
+                "mbti": mbti,
+                "chatRoomId": chatRoomId
+            },
+            {
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }
+        );
+        console.log(response.data);
+        return response.data;
+    } catch (error) {
+        console.error('Error initializing chat:', error);
+        throw error;
+    }
+};
+
 
 export {
     sendMessage,
     sendGetRequest,
-    sendPostRequest
+    sendPostRequest,
+    initializeChat
 }

--- a/src/main/java/com/example/mzting/config/ClaudeConfig.java
+++ b/src/main/java/com/example/mzting/config/ClaudeConfig.java
@@ -19,4 +19,8 @@ public class ClaudeConfig {
     // Claude API의 키
     @Value("${claude.api.key}")
     private String apiKey;
+
+    // Claude API의 고정 프롬프트
+    @Value("${claude.fixed-prompt}")
+    private String fixedPrompt;
 }

--- a/src/main/java/com/example/mzting/config/ClaudeConfig.java
+++ b/src/main/java/com/example/mzting/config/ClaudeConfig.java
@@ -4,13 +4,19 @@ import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Claude API 설정 클래스
+ * claude.api.url과 claude.api.key 설정을 로드하여 보관
+ */
 @Getter
 @Configuration
 public class ClaudeConfig {
+
+    // Claude API의 URL
     @Value("${claude.api.url}")
     private String apiUrl;
 
+    // Claude API의 키
     @Value("${claude.api.key}")
     private String apiKey;
-
 }

--- a/src/main/java/com/example/mzting/config/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/mzting/config/OAuth2AuthenticationSuccessHandler.java
@@ -11,25 +11,53 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+/**
+ * OAuth2 인증 성공 처리기 클래스
+ * OAuth2 인증 성공 시 JWT 토큰을 생성하고 응답에 추가하는 역할을 수행
+ */
 @Component
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    // JWT 토큰 생성 제공자
     private final JwtTokenProvider jwtTokenProvider;
 
+    /**
+     * OAuth2AuthenticationSuccessHandler 생성자
+     * JwtTokenProvider를 주입받아 초기화
+     *
+     * @param jwtTokenProvider JWT 토큰 제공자
+     */
     @Autowired
     public OAuth2AuthenticationSuccessHandler(JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
+    /**
+     * 인증 성공 시 호출되는 메서드
+     * JWT 토큰을 생성하고 응답 헤더에 추가
+     *
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     * @param authentication 인증 객체
+     * @throws IOException 입출력 예외
+     * @throws ServletException 서블릿 예외
+     */
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
-        // 여기서 JWT 토큰을 생성하고 response에 추가할 수 있습니다.
+        // JWT 토큰 생성
         String token = jwtTokenProvider.generateToken(authentication);
+
+        // 응답 헤더에 JWT 토큰 추가
         response.addHeader("Authorization", "Bearer " + token);
+
+        // 응답 본문에 JWT 토큰 추가
         response.getWriter().write("JWT Token: " + token);
 
-        setDefaultTargetUrl("/qqqaaa");  // 로그인 성공 후 리다이렉트할 URL
+        // 로그인 성공 후 리다이렉트할 URL 설정
+        setDefaultTargetUrl("/qqqaaa");
+
+        // 부모 클래스의 onAuthenticationSuccess 메서드 호출
         super.onAuthenticationSuccess(request, response, authentication);
     }
 }

--- a/src/main/java/com/example/mzting/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/mzting/config/RestTemplateConfig.java
@@ -6,14 +6,28 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import java.time.Duration;
 
+/**
+ * RestTemplate 설정 클래스
+ * RestTemplate의 커넥션 타임아웃 및 읽기 타임아웃을 설정
+ */
 @Configuration
 public class RestTemplateConfig {
 
+    /**
+     * RestTemplate 빈을 생성하는 메서드
+     * 커넥션 타임아웃과 읽기 타임아웃을 설정하여 RestTemplate 객체를 생성
+     *
+     * @param builder RestTemplateBuilder 객체
+     * @return 설정된 RestTemplate 객체
+     */
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder
-            .setConnectTimeout(Duration.ofSeconds(10))
-            .setReadTimeout(Duration.ofSeconds(30))
-            .build();
+                // 커넥션 타임아웃 설정 (10초)
+                .setConnectTimeout(Duration.ofSeconds(10))
+                // 읽기 타임아웃 설정 (30초)
+                .setReadTimeout(Duration.ofSeconds(30))
+                // RestTemplate 빌드
+                .build();
     }
 }

--- a/src/main/java/com/example/mzting/config/SecurityConfig.java
+++ b/src/main/java/com/example/mzting/config/SecurityConfig.java
@@ -24,15 +24,35 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 
+/**
+ * Spring Security 설정 클래스
+ * 애플리케이션의 보안 설정을 구성
+ */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    // OAuth2 클라이언트 등록 저장소
     private final ClientRegistrationRepository clientRegistrationRepository;
+
+    // OAuth2 인증 성공 처리기
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    // JWT 토큰 제공자
     private final JwtTokenProvider jwtTokenProvider;
+
+    // 사용자 정의 인증 서비스
     private final CustomUserDetailsService customUserDetailsService;
 
+    /**
+     * SecurityConfig 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param clientRegistrationRepository OAuth2 클라이언트 등록 저장소
+     * @param oAuth2AuthenticationSuccessHandler OAuth2 인증 성공 처리기
+     * @param jwtTokenProvider JWT 토큰 제공자
+     * @param customUserDetailsService 사용자 정의 인증 서비스
+     */
     public SecurityConfig(ClientRegistrationRepository clientRegistrationRepository,
                           OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler,
                           JwtTokenProvider jwtTokenProvider,
@@ -43,15 +63,30 @@ public class SecurityConfig {
         this.customUserDetailsService = customUserDetailsService;
     }
 
+    /**
+     * 보안 필터 체인 설정 메서드
+     * 보안 필터 체인을 구성하고 반환
+     *
+     * @param http HttpSecurity 객체
+     * @return 구성된 SecurityFilterChain 객체
+     * @throws Exception 예외
+     */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                // CSRF 보호 비활성화
                 .csrf(csrf -> csrf.disable())
+
+                // CORS 설정
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+                // 요청 권한 설정
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers("/api/**", "/login", "/oauth2/**", "/send-verification", "/verify-email", "/home").permitAll()
                         .anyRequest().authenticated()
                 )
+
+                // OAuth2 로그인 설정
                 .oauth2Login(oauth2 -> oauth2
                         .loginPage("/login")
                         .successHandler(oAuth2AuthenticationSuccessHandler)
@@ -79,11 +114,19 @@ public class SecurityConfig {
                                 )
                         )
                 )
+
+                // JWT 인증 필터 추가
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
+    /**
+     * CORS 설정 소스 메서드
+     * CORS 구성을 정의하고 반환
+     *
+     * @return 설정된 CorsConfigurationSource 객체
+     */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
@@ -96,11 +139,25 @@ public class SecurityConfig {
         return source;
     }
 
+    /**
+     * 인증 관리자 빈 설정 메서드
+     * AuthenticationManager를 설정하고 반환
+     *
+     * @param authenticationConfiguration 인증 구성 객체
+     * @return 설정된 AuthenticationManager 객체
+     * @throws Exception 예외
+     */
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
     }
 
+    /**
+     * 비밀번호 인코더 빈 설정 메서드
+     * BCryptPasswordEncoder를 설정하고 반환
+     *
+     * @return 설정된 PasswordEncoder 객체
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/src/main/java/com/example/mzting/config/WebConfig.java
+++ b/src/main/java/com/example/mzting/config/WebConfig.java
@@ -4,15 +4,29 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * 웹 설정 클래스
+ * 애플리케이션의 CORS 설정을 구성
+ */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    /**
+     * CORS 매핑 설정 메서드
+     * 특정 경로 패턴에 대한 CORS 설정을 정의
+     *
+     * @param registry CORS 레지스트리 객체
+     */
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
+                // 허용할 오리진 설정
                 .allowedOrigins("http://localhost:3000")
+                // 허용할 HTTP 메서드 설정
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                // 허용할 헤더 설정
                 .allowedHeaders("*")
+                // 자격 증명 허용 설정
                 .allowCredentials(true);
     }
 }

--- a/src/main/java/com/example/mzting/controller/AuthController.java
+++ b/src/main/java/com/example/mzting/controller/AuthController.java
@@ -11,17 +11,31 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 인증 관련 요청을 처리하는 컨트롤러 클래스
+ * 이메일 인증과 관련된 API 엔드포인트를 제공
+ */
 @RestController
 public class AuthController {
 
+    // 로거 객체
     private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
 
+    // 사용자 저장소
     @Autowired
     private UserRepository userRepository;
 
+    // 이메일 서비스
     @Autowired
     private EmailService emailService;
 
+    /**
+     * 이메일 인증 처리 메서드
+     * 주어진 이메일을 인증하고 결과를 반환
+     *
+     * @param email 인증할 이메일 주소
+     * @return 인증 결과에 따른 응답 객체
+     */
     @GetMapping("/verify-email")
     public ResponseEntity<String> verifyEmail(@RequestParam String email) {
         logger.info("Verifying email: {}", email);
@@ -36,6 +50,13 @@ public class AuthController {
         return ResponseEntity.badRequest().body("유효하지 않은 이메일입니다.");
     }
 
+    /**
+     * 인증 이메일 발송 처리 메서드
+     * 주어진 이메일 주소로 인증 이메일을 발송하고 결과를 반환
+     *
+     * @param email 인증 이메일을 발송할 이메일 주소
+     * @return 발송 결과에 따른 응답 객체
+     */
     @GetMapping("/send-verification")
     public ResponseEntity<String> sendVerification(@RequestParam String email) {
         logger.info("Sending verification email to: {}", email);

--- a/src/main/java/com/example/mzting/controller/ChatController.java
+++ b/src/main/java/com/example/mzting/controller/ChatController.java
@@ -15,20 +15,43 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * 채팅 관련 요청을 처리하는 컨트롤러 클래스
+ * Claude API와 상호작용하고 채팅 데이터를 관리
+ */
 @RestController
 @RequestMapping("/api")
 @CrossOrigin(origins = "http://localhost:3000")
 public class ChatController {
+
+    // 로거 객체
     private static final Logger logger = LoggerFactory.getLogger(ClaudeApiService.class);
 
+    // Claude API 서비스
     private final ClaudeApiService claudeApiService;
+
+    // 채팅 서비스
     private final ChatService chatService;
 
+    /**
+     * ChatController 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param claudeApiService Claude API 서비스
+     * @param chatService 채팅 서비스
+     */
     public ChatController(ClaudeApiService claudeApiService, ChatService chatService) {
         this.claudeApiService = claudeApiService;
         this.chatService = chatService;
     }
 
+    /**
+     * Claude에게 질문을 보내는 엔드포인트
+     * 사용자 메시지를 저장하고 Claude의 응답을 반환
+     *
+     * @param userMessageObj 사용자 메시지 객체
+     * @return Claude의 응답을 포함한 ResponseEntity 객체
+     */
     @PostMapping(value = "/ask-claude", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> askClaude(@RequestBody UserMessage userMessageObj) {
         try {
@@ -39,18 +62,22 @@ public class ChatController {
             // 사용자 메시지를 DB에 저장
             chatService.saveUserMessage(userMessage, chatRoomId);
 
+            // 사용자 요청 추가
             chatService.addUserRequest(userMessage);
 
+            // Claude API를 호출하여 응답 받기
             ClaudeResponse claudeResponse = claudeApiService.getClaudeResponseByMbti(
                     userMbti,
                     chatService.getMessagesForClaudeApi()
             );
 
+            // Claude의 응답을 추가
             chatService.addClaudeResponse(claudeResponse.getText());
 
-            // Claude의 응답도 DB에 저장
+            // Claude의 응답을 DB에 저장
             chatService.saveUserMessage(claudeResponse, chatRoomId);
 
+            // 응답 맵 생성
             Map<String, Object> response = new HashMap<>();
             response.put("claudeResponse", claudeResponse);
 
@@ -65,6 +92,13 @@ public class ChatController {
         }
     }
 
+    /**
+     * 컨텍스트를 업데이트하는 메서드
+     * 사용자 메시지와 AI 응답을 분석하여 컨텍스트를 업데이트
+     *
+     * @param userMessage 사용자 메시지
+     * @param aiResponse AI 응답
+     */
     private void updateContext(String userMessage, String aiResponse) {
         // 사용자 메시지와 AI 응답을 분석하여 컨텍스트 업데이트
         // 예: 선호하는 음식, 취미 등을 추출하여 저장
@@ -74,16 +108,33 @@ public class ChatController {
         // 더 많은 컨텍스트 추출 로직 추가
     }
 
+    /**
+     * 저장된 응답을 가져오는 엔드포인트
+     *
+     * @return 저장된 응답 목록을 포함한 ResponseEntity 객체
+     */
     @GetMapping("/get-responses")
     public ResponseEntity<List<String>> getResponses() {
         return ResponseEntity.ok(chatService.getSavedResponses());
     }
 
+    /**
+     * 저장된 대화를 가져오는 엔드포인트
+     *
+     * @return 저장된 대화 목록을 포함한 ResponseEntity 객체
+     */
     @GetMapping("/get-conversation")
     public ResponseEntity<List<String>> getConversation() {
         return ResponseEntity.ok(chatService.getConversation());
     }
 
+    /**
+     * 채팅을 초기화하는 엔드포인트
+     * 주어진 사용자 메시지 객체를 바탕으로 채팅을 초기화
+     *
+     * @param userMessageObj 사용자 메시지 객체
+     * @return 초기화 결과를 포함한 ResponseEntity 객체
+     */
     @PostMapping("/initialize-chat")
     public ResponseEntity<?> initializeChat(@RequestBody UserMessage userMessageObj) {
         logger.info("Initializing chat for user message: {}", userMessageObj);

--- a/src/main/java/com/example/mzting/controller/ChatController.java
+++ b/src/main/java/com/example/mzting/controller/ChatController.java
@@ -34,7 +34,7 @@ public class ChatController {
         try {
             String userMessage = userMessageObj.getMessage();
             String userMbti = userMessageObj.getMbti();
-            Long chatRoomId = 1L; // 추가: 채팅방 ID를 받아옴
+            Long chatRoomId = userMessageObj.getChatRoomId();
 
             // 사용자 메시지를 DB에 저장
             chatService.saveUserMessage(userMessage, chatRoomId);
@@ -43,18 +43,14 @@ public class ChatController {
 
             ClaudeResponse claudeResponse = claudeApiService.getClaudeResponseByMbti(
                     userMbti,
-                    chatService.getMessagesForClaudeApi(),
-                    chatService.getFullContext()
+                    chatService.getMessagesForClaudeApi()
             );
 
             chatService.addClaudeResponse(claudeResponse.getText());
 
-            // 컨텍스트 업데이트
-            updateContext(userMessage, claudeResponse.getText());
-
-            // Claude의 응답도 DB에 저장 (선택적)
+            // Claude의 응답도 DB에 저장
             chatService.saveUserMessage(claudeResponse, chatRoomId);
-          
+
             Map<String, Object> response = new HashMap<>();
             response.put("claudeResponse", claudeResponse);
 
@@ -64,11 +60,11 @@ public class ChatController {
             logger.error("Error processing request", e);
             Map<String, String> errorResponse = new HashMap<>();
             errorResponse.put("error", "Error processing request: " + e.getMessage());
-            errorResponse.put("stackTrace", Arrays.toString(e.getStackTrace()));
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(errorResponse);
         }
     }
+
     private void updateContext(String userMessage, String aiResponse) {
         // 사용자 메시지와 AI 응답을 분석하여 컨텍스트 업데이트
         // 예: 선호하는 음식, 취미 등을 추출하여 저장
@@ -86,5 +82,44 @@ public class ChatController {
     @GetMapping("/get-conversation")
     public ResponseEntity<List<String>> getConversation() {
         return ResponseEntity.ok(chatService.getConversation());
+    }
+
+    @PostMapping("/initialize-chat")
+    public ResponseEntity<?> initializeChat(@RequestBody UserMessage userMessageObj) {
+        logger.info("Initializing chat for user message: {}", userMessageObj);
+
+        try {
+            String userMbti = userMessageObj.getMbti();
+            Long chatRoomId = userMessageObj.getChatRoomId(); // 채팅방 ID를 UserMessage에서 받아오도록 수정
+
+            if (userMbti == null || userMbti.isEmpty()) {
+                logger.warn("MBTI is null or empty");
+                return ResponseEntity.badRequest().body("MBTI is required");
+            }
+
+            if (chatRoomId == null) {
+                logger.warn("ChatRoomId is null");
+                return ResponseEntity.badRequest().body("ChatRoomId is required");
+            }
+
+            if (!chatService.isInitialized(chatRoomId)) {
+                logger.info("Initializing chat for MBTI: {} and ChatRoomId: {}", userMbti, chatRoomId);
+                ClaudeResponse claudeResponse = claudeApiService.initializeClaudeChat(userMbti);
+                chatService.saveUserMessage(claudeResponse, chatRoomId);
+                chatService.setInitialized(chatRoomId, true);
+
+                Map<String, Object> response = new HashMap<>();
+                response.put("claudeResponse", claudeResponse);
+                logger.info("Chat initialized successfully for ChatRoomId: {}", chatRoomId);
+                return ResponseEntity.ok(response);
+            } else {
+                logger.info("Chat already initialized for ChatRoomId: {}", chatRoomId);
+                return ResponseEntity.ok("Chat already initialized");
+            }
+        } catch (Exception e) {
+            logger.error("Error initializing chat", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Error initializing chat: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/example/mzting/controller/ChatResultController.java
+++ b/src/main/java/com/example/mzting/controller/ChatResultController.java
@@ -1,22 +1,38 @@
 package com.example.mzting.controller;
 
 import com.example.mzting.dto.ChatResultResponse;
-import com.example.mzting.entity.Chat;
 import com.example.mzting.service.ChatResultService;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
+/**
+ * 채팅 결과 관련 요청을 처리하는 컨트롤러 클래스
+ * 채팅 결과 요약을 제공하는 API 엔드포인트를 정의
+ */
 @RestController
 @RequestMapping("/api")
 @CrossOrigin(origins = "http://localhost:3000")
 public class ChatResultController {
+
+    // 채팅 결과 서비스
     private final ChatResultService chatResultService;
 
+    /**
+     * ChatResultController 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param chatResultService 채팅 결과 서비스
+     */
     public ChatResultController(ChatResultService chatResultService) {
         this.chatResultService = chatResultService;
     }
 
+    /**
+     * 채팅 요약을 가져오는 엔드포인트
+     * 주어진 채팅방 ID에 대한 봇 메시지와 요약을 반환
+     *
+     * @param chatRoomId 채팅방 ID
+     * @return 채팅 요약을 포함한 ChatResultResponse 객체
+     */
     @GetMapping("chat/result/{chatRoomId}")
     public ChatResultResponse getChatSummary(@PathVariable Long chatRoomId) {
         return chatResultService.getBotMessagesWithSummary(chatRoomId);

--- a/src/main/java/com/example/mzting/controller/ChatRoomController.java
+++ b/src/main/java/com/example/mzting/controller/ChatRoomController.java
@@ -9,28 +9,59 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * 채팅방 관련 요청을 처리하는 컨트롤러 클래스
+ * 채팅방 생성, 목록 조회, 히스토리 조회 등의 API 엔드포인트를 제공
+ */
 @RestController
 @RequestMapping("/api")
 @CrossOrigin(origins = "http://localhost:3000")
 public class ChatRoomController {
+
+    // 채팅방 서비스
     private final ChatRoomService chatRoomService;
 
+    /**
+     * ChatRoomController 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param chatRoomService 채팅방 서비스
+     */
     public ChatRoomController(ChatRoomService chatRoomService) {
         this.chatRoomService = chatRoomService;
     }
 
+    /**
+     * 채팅방을 생성하는 엔드포인트
+     * 주어진 요청 객체를 바탕으로 채팅방을 생성하고 반환
+     *
+     * @param request 채팅방 생성 요청 객체
+     * @return 생성된 채팅방을 포함한 ResponseEntity 객체
+     */
     @PostMapping("/chatroom/create")
     public ResponseEntity<ChatRoom> createChatRoom(@RequestBody ChatRoomRequest request) {
         ChatRoom chatRoom = chatRoomService.createChatRoom(request);
         return ResponseEntity.ok(chatRoom);
     }
 
+    /**
+     * 사용자 ID에 따른 채팅방 목록을 조회하는 엔드포인트
+     *
+     * @param userId 사용자 ID
+     * @return 채팅방 목록을 포함한 ResponseEntity 객체
+     */
     @GetMapping("/chatroom/list/{userId}")
     public ResponseEntity<List<ChatRoom>> getChatRoomList(@PathVariable Long userId) {
         List<ChatRoom> chatRooms = chatRoomService.getChatRoomsByUserId(userId);
         return ResponseEntity.ok(chatRooms);
     }
 
+    /**
+     * 특정 채팅방의 히스토리를 조회하는 엔드포인트
+     *
+     * @param chatRoomId 채팅방 ID
+     * @return 채팅방과 히스토리를 포함한 ChatRoomWithHistoryDTO 객체를 담은 ResponseEntity 객체
+     */
     @GetMapping("/chatroom/{chatRoomId}")
     public ResponseEntity<ChatRoomWithHistoryDTO> getChatRoomWithHistory(@PathVariable Long chatRoomId) {
         ChatRoomWithHistoryDTO chatRoomWithHistory = chatRoomService.getChatRoomWithHistory(chatRoomId);

--- a/src/main/java/com/example/mzting/controller/CommentController.java
+++ b/src/main/java/com/example/mzting/controller/CommentController.java
@@ -11,19 +11,39 @@ import org.springframework.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * 댓글 관련 요청을 처리하는 컨트롤러 클래스
+ * 댓글 생성 및 조회와 관련된 API 엔드포인트를 정의
+ */
 @RestController
 @RequestMapping("/api/posts/{postId}/comments")
 public class CommentController {
 
+    // 로거 객체
     private static final Logger logger = LoggerFactory.getLogger(CommentController.class);
 
+    // 댓글 서비스
     private final CommentService commentService;
 
+    /**
+     * CommentController 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param commentService 댓글 서비스
+     */
     @Autowired
     public CommentController(CommentService commentService) {
         this.commentService = commentService;
     }
 
+    /**
+     * 댓글을 생성하는 엔드포인트
+     * 주어진 요청 객체를 바탕으로 댓글을 생성하고 결과를 반환
+     *
+     * @param postId 게시물 ID
+     * @param PostPostsCommentRequest 댓글 생성 요청 객체
+     * @return 댓글 생성 결과를 포함한 ResponseEntity 객체
+     */
     @PostMapping
     public ResponseEntity<CommentDTO.PostPostsCommentsResponse> createComment(
             @PathVariable Long postId,
@@ -37,7 +57,6 @@ public class CommentController {
             System.out.println("postId : " + postId);
             commentService.saveComment(comment);
 
-
             CommentDTO.PostPostsCommentsResponse response = new CommentDTO.PostPostsCommentsResponse();
             response.setSuccess(true);
             return ResponseEntity.ok(response);
@@ -49,6 +68,14 @@ public class CommentController {
         }
     }
 
+    /**
+     * 특정 게시물의 댓글을 조회하는 엔드포인트
+     *
+     * @param postId 게시물 ID
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 20)
+     * @return 댓글 목록을 포함한 ResponseEntity 객체
+     */
     @GetMapping
     public ResponseEntity<CommentDTO.GetPostsCommentsResponse> getCommentsByPostId(
             @PathVariable Long postId,

--- a/src/main/java/com/example/mzting/controller/MBTIQuestionController.java
+++ b/src/main/java/com/example/mzting/controller/MBTIQuestionController.java
@@ -6,26 +6,49 @@ import com.example.mzting.repository.MBTIQuestionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-
 import java.util.List;
 
+/**
+ * MBTI 질문 관련 요청을 처리하는 컨트롤러 클래스
+ * 질문 조회 및 답변 제출과 관련된 API 엔드포인트를 정의
+ */
 @RestController
 @RequestMapping("/api/question")
 public class MBTIQuestionController {
+
+    // MBTI 질문 저장소
     @Autowired
     private MBTIQuestionRepository questionRepository;
 
+    /**
+     * 모든 MBTI 질문을 조회하는 엔드포인트
+     *
+     * @return 모든 MBTI 질문 목록
+     */
     @GetMapping
     public List<MBTIQuestion> getQuestions() {
         return questionRepository.findAll();
     }
 
+    /**
+     * MBTI 답변을 제출하는 엔드포인트
+     * 주어진 답변 리스트를 바탕으로 MBTI 유형을 판별하고 반환
+     *
+     * @param answers 사용자가 제출한 답변 리스트
+     * @return 판별된 MBTI 유형 문자열
+     */
     @PostMapping("/submit")
     public String submitAnswers(@RequestBody List<Answer> answers) {
         // MBTI 판별 로직
         return determineMBTI(answers);
     }
 
+    /**
+     * 주어진 답변 리스트를 바탕으로 MBTI 유형을 판별하는 메서드
+     *
+     * @param answers 사용자가 제출한 답변 리스트
+     * @return 판별된 MBTI 유형 문자열
+     */
     private String determineMBTI(List<Answer> answers) {
         int E = 0, I = 0, S = 0, N = 0, T = 0, F = 0, J = 0, P = 0;
         for (Answer answer : answers) {

--- a/src/main/java/com/example/mzting/controller/MBTIRecommendController.java
+++ b/src/main/java/com/example/mzting/controller/MBTIRecommendController.java
@@ -6,16 +6,34 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * MBTI 추천 관련 요청을 처리하는 컨트롤러 클래스
+ * MBTI 호환성 추천과 관련된 API 엔드포인트를 정의
+ */
 @RestController
 @RequestMapping("/api/recommend")
 public class MBTIRecommendController {
+
+    // MBTI 추천 서비스
     private final MBTIRecommendService service;
 
+    /**
+     * MBTIRecommendController 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param service MBTI 추천 서비스
+     */
     @Autowired
     public MBTIRecommendController(MBTIRecommendService service) {
         this.service = service;
     }
 
+    /**
+     * 주어진 MBTI에 대한 호환성을 조회하는 엔드포인트
+     *
+     * @param mbti MBTI 유형 문자열
+     * @return 호환성 추천 결과를 포함한 ResponseEntity 객체
+     */
     @GetMapping("/compatibility/{mbti}")
     public ResponseEntity<MBTIRecommendDTO.GetMBTIRecommendResponse> getCompatibility(@PathVariable String mbti) {
         return service.getCompatibilityByMBTI(mbti)

--- a/src/main/java/com/example/mzting/controller/ProfileController.java
+++ b/src/main/java/com/example/mzting/controller/ProfileController.java
@@ -10,19 +10,34 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * 프로필 관련 요청을 처리하는 컨트롤러 클래스
+ * 프로필 조회와 관련된 API 엔드포인트를 정의
+ */
 @RestController
 @RequestMapping("/api/profiles")
 public class ProfileController {
 
+    // 프로필 서비스
     @Autowired
     private ProfileService profileService;
 
-
+    /**
+     * 모든 프로필을 조회하는 엔드포인트
+     *
+     * @return 모든 프로필 목록
+     */
     @GetMapping
     public List<Profile> getProfiles() {
         return profileService.getAllProfiles();
     }
 
+    /**
+     * 특정 MBTI 유형에 해당하는 프로필을 조회하는 엔드포인트
+     *
+     * @param type MBTI 유형 문자열
+     * @return 해당 MBTI 유형의 프로필 목록
+     */
     @GetMapping("/mbti/{type}")
     public List<Profile> getProfilesByMbti(@PathVariable String type) {
         return profileService.getProfilesByMbti(type);

--- a/src/main/java/com/example/mzting/controller/UserController.java
+++ b/src/main/java/com/example/mzting/controller/UserController.java
@@ -17,18 +17,33 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 사용자 인증 및 관리와 관련된 요청을 처리하는 컨트롤러 클래스
+ * 사용자 등록, 로그인, 현재 사용자 조회와 관련된 API 엔드포인트를 정의
+ */
 @RestController
 @RequestMapping("/api/auth")
 public class UserController {
+
+    // 사용자 서비스
     @Autowired
     private UserService userService;
 
+    // 인증 관리자
     @Autowired
     private AuthenticationManager authenticationManager;
 
+    // JWT 토큰 제공자
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
+    /**
+     * 사용자 등록 엔드포인트
+     * 주어진 사용자 정보를 바탕으로 새로운 사용자를 등록
+     *
+     * @param user 사용자 정보 객체
+     * @return 등록된 사용자 정보 또는 오류 메시지를 포함한 ResponseEntity 객체
+     */
     @PostMapping("/register")
     public ResponseEntity<?> registerUser(@RequestBody User user) {
         if (userService.findByUsername(user.getUsername()) != null) {
@@ -38,6 +53,13 @@ public class UserController {
         return ResponseEntity.ok(registeredUser);
     }
 
+    /**
+     * 사용자 로그인 엔드포인트
+     * 주어진 로그인 요청 정보를 바탕으로 사용자를 인증하고 JWT 토큰을 반환
+     *
+     * @param loginRequest 로그인 요청 정보 객체
+     * @return JWT 토큰 또는 오류 메시지를 포함한 ResponseEntity 객체
+     */
     @PostMapping("/login")
     public ResponseEntity<?> loginUser(@RequestBody LoginRequest loginRequest) {
         try {
@@ -57,6 +79,11 @@ public class UserController {
         }
     }
 
+    /**
+     * 현재 인증된 사용자 정보를 조회하는 엔드포인트
+     *
+     * @return 현재 사용자 이름 또는 인증되지 않은 상태에 대한 메시지를 포함한 ResponseEntity 객체
+     */
     @GetMapping("/current")
     public ResponseEntity<?> getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -75,6 +102,9 @@ public class UserController {
     }
 }
 
+/**
+ * 인증 응답을 담는 DTO 클래스
+ */
 @Getter
 @Setter
 @AllArgsConstructor
@@ -82,6 +112,9 @@ class AuthResponse {
     private String token;
 }
 
+/**
+ * 로그인 요청 정보를 담는 DTO 클래스
+ */
 @Getter
 @Setter
 class LoginRequest {

--- a/src/main/java/com/example/mzting/dto/Answer.java
+++ b/src/main/java/com/example/mzting/dto/Answer.java
@@ -1,18 +1,23 @@
 package com.example.mzting.dto;
 
-
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
+/**
+ * MBTI 질문에 대한 답변을 나타내는 DTO 클래스
+ * 질문 ID와 사용자가 선택한 옵션을 포함
+ */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Answer {
-    private Long questionId;
-    private String option;
 
-    // Getters and Setters
+    // 질문 ID
+    private Long questionId;
+
+    // 사용자가 선택한 옵션
+    private String option;
 }

--- a/src/main/java/com/example/mzting/dto/ChatResultResponse.java
+++ b/src/main/java/com/example/mzting/dto/ChatResultResponse.java
@@ -5,12 +5,22 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * 채팅 결과 응답을 나타내는 DTO 클래스
+ * 채팅 점수, 평가 요약, 느낌 요약을 포함
+ */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatResultResponse {
+
+    // 채팅 점수
     private Integer score;
+
+    // 평가 요약
     private String summaryEval;
+
+    // 느낌 요약
     private String summaryFeel;
 }

--- a/src/main/java/com/example/mzting/dto/ChatRoomRequest.java
+++ b/src/main/java/com/example/mzting/dto/ChatRoomRequest.java
@@ -1,17 +1,26 @@
 package com.example.mzting.dto;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * 채팅방 생성 요청을 나타내는 DTO 클래스
+ * 채팅방 이름, 사용자 ID, 프로필 ID를 포함
+ */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatRoomRequest {
+
+    // 채팅방 이름
     private String name;
+
+    // 사용자 ID
     private Long userId;
+
+    // 프로필 ID
     private Integer profileId;
 }

--- a/src/main/java/com/example/mzting/dto/ChatRoomWithHistoryDTO.java
+++ b/src/main/java/com/example/mzting/dto/ChatRoomWithHistoryDTO.java
@@ -7,12 +7,26 @@ import lombok.Setter;
 
 import java.util.List;
 
+/**
+ * 채팅방과 그 히스토리를 나타내는 DTO 클래스
+ * 채팅방 정보와 채팅 히스토리를 포함
+ */
 @Getter
 @Setter
 public class ChatRoomWithHistoryDTO {
+
+    // 채팅방 정보
     private ChatRoom chatRoom;
+
+    // 채팅 히스토리 목록
     private List<Chat> chatHistory;
 
+    /**
+     * ChatRoomWithHistoryDTO 생성자
+     *
+     * @param chatRoom 채팅방 정보
+     * @param chatHistory 채팅 히스토리 목록
+     */
     public ChatRoomWithHistoryDTO(ChatRoom chatRoom, List<Chat> chatHistory) {
         this.chatRoom = chatRoom;
         this.chatHistory = chatHistory;

--- a/src/main/java/com/example/mzting/dto/ClaudeResponse.java
+++ b/src/main/java/com/example/mzting/dto/ClaudeResponse.java
@@ -3,19 +3,43 @@ package com.example.mzting.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Claude API의 응답을 나타내는 DTO 클래스
+ * 텍스트, 느낌, 평가, 점수, 단계 완료 상태, 오류 메시지를 포함
+ */
 @Setter
 @Getter
 public class ClaudeResponse {
+
+    // 응답 텍스트
     private String text;
+
+    // 느낌 요약
     private String feel;
+
+    // 평가 요약
     private String evaluation;
+
+    // 점수
     private int score;
+
+    // 단계 1 완료 상태
     private boolean stage1Complete;
+
+    // 단계 2 완료 상태
     private boolean stage2Complete;
+
+    // 단계 3 완료 상태
     private boolean stage3Complete;
+
+    // 오류 메시지
     private String errorMessage;
 
-    // toString 메서드 오버라이드
+    /**
+     * 객체의 문자열 표현을 반환
+     *
+     * @return 객체의 문자열 표현
+     */
     @Override
     public String toString() {
         return "ClaudeResponse{" +
@@ -26,6 +50,7 @@ public class ClaudeResponse {
                 ", stage1Complete=" + stage1Complete +
                 ", stage2Complete=" + stage2Complete +
                 ", stage3Complete=" + stage3Complete +
+                ", errorMessage='" + errorMessage + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/example/mzting/dto/CommentDTO.java
+++ b/src/main/java/com/example/mzting/dto/CommentDTO.java
@@ -7,10 +7,14 @@ import lombok.AllArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.data.domain.Page;
-
-
+/**
+ * 댓글 관련 DTO 클래스들을 정의
+ */
 public class CommentDTO {
+
+    /**
+     * 게시물 댓글 작성 요청 DTO 클래스
+     */
     @Getter
     @Setter
     @NoArgsConstructor
@@ -21,6 +25,9 @@ public class CommentDTO {
         private Boolean isLike;
     }
 
+    /**
+     * 게시물 댓글 작성 응답 DTO 클래스
+     */
     @Getter
     @Setter
     @NoArgsConstructor
@@ -29,6 +36,9 @@ public class CommentDTO {
         private Boolean success;
     }
 
+    /**
+     * 게시물 댓글 조회 요청 DTO 클래스
+     */
     @Getter
     @Setter
     @NoArgsConstructor
@@ -36,9 +46,11 @@ public class CommentDTO {
     public static class GetPostsCommentsRequest {
         private int page;
         private int size;
-
     }
 
+    /**
+     * 게시물 댓글 조회 응답 DTO 클래스
+     */
     @Getter
     @Setter
     @NoArgsConstructor
@@ -50,6 +62,9 @@ public class CommentDTO {
         private PaginationInfo paginationInfo;
     }
 
+    /**
+     * 댓글 정보 DTO 클래스
+     */
     @Getter
     @Setter
     @NoArgsConstructor
@@ -61,6 +76,9 @@ public class CommentDTO {
         private String username;
     }
 
+    /**
+     * 좋아요 및 싫어요 개수 정보 DTO 클래스
+     */
     @Getter
     @Setter
     @NoArgsConstructor
@@ -70,6 +88,9 @@ public class CommentDTO {
         private long totalDislikeCount;
     }
 
+    /**
+     * 페이지네이션 정보 DTO 클래스
+     */
     @Getter
     @Setter
     @NoArgsConstructor

--- a/src/main/java/com/example/mzting/dto/LikeDislikeCountInfo.java
+++ b/src/main/java/com/example/mzting/dto/LikeDislikeCountInfo.java
@@ -1,14 +1,22 @@
 package com.example.mzting.dto;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
+/**
+ * 좋아요 및 싫어요 개수 정보를 나타내는 DTO 클래스
+ */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class LikeDislikeCountInfo {
+
+    // 총 좋아요 개수
     private long totalLikeCount;
+
+    // 총 싫어요 개수
     private long totalDislikeCount;
 }

--- a/src/main/java/com/example/mzting/dto/LoginRequest.java
+++ b/src/main/java/com/example/mzting/dto/LoginRequest.java
@@ -3,9 +3,16 @@ package com.example.mzting.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * 로그인 요청 정보를 나타내는 DTO 클래스
+ */
 @Getter
 @Setter
 public class LoginRequest {
+
+    // 사용자 이름
     private String username;
+
+    // 사용자 비밀번호
     private String password;
 }

--- a/src/main/java/com/example/mzting/dto/MBTIRecommendDTO.java
+++ b/src/main/java/com/example/mzting/dto/MBTIRecommendDTO.java
@@ -1,14 +1,24 @@
 package com.example.mzting.dto;
+
 import lombok.Data;
 import java.util.List;
 import java.util.Map;
 
-
+/**
+ * MBTI 추천 관련 DTO 클래스
+ */
 public class MBTIRecommendDTO {
 
+    /**
+     * MBTI 추천 응답 DTO 클래스
+     */
     @Data
     public static class GetMBTIRecommendResponse {
+
+        // MBTI 유형
         private String mbti;
+
+        // 호환성 그룹 맵
         private Map<String, List<String>> compatibilityGroups;
     }
 }

--- a/src/main/java/com/example/mzting/dto/UserMessage.java
+++ b/src/main/java/com/example/mzting/dto/UserMessage.java
@@ -1,12 +1,12 @@
 package com.example.mzting.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class UserMessage {
     private String message;
     private String mbti;
-
-    // getter and setter
+    private Long chatRoomId;
 }
-

--- a/src/main/java/com/example/mzting/dto/UserMessage.java
+++ b/src/main/java/com/example/mzting/dto/UserMessage.java
@@ -3,10 +3,20 @@ package com.example.mzting.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * 사용자 메시지를 나타내는 DTO 클래스
+ * 메시지 내용, MBTI 유형, 채팅방 ID를 포함
+ */
 @Getter
 @Setter
 public class UserMessage {
+
+    // 메시지 내용
     private String message;
+
+    // 사용자 MBTI 유형
     private String mbti;
+
+    // 채팅방 ID
     private Long chatRoomId;
 }

--- a/src/main/java/com/example/mzting/entity/CharacterHobby.java
+++ b/src/main/java/com/example/mzting/entity/CharacterHobby.java
@@ -3,18 +3,24 @@ package com.example.mzting.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+/**
+ * 캐릭터 취미 엔티티 클래스
+ * 프로필과 취미 간의 관계를 나타냄
+ */
 @Entity
 @Table(name = "character_hobbies")
 public class CharacterHobby {
+
+    // 프로필 엔티티
     @Id
     @ManyToOne
     @JoinColumn(name = "profile_id")
     private Profile profile;
 
+    // 취미 엔티티
     @Getter
     @Id
     @ManyToOne
     @JoinColumn(name = "hobby_id")
     private Hobby hobby;
-
 }

--- a/src/main/java/com/example/mzting/entity/CharacterKeyword.java
+++ b/src/main/java/com/example/mzting/entity/CharacterKeyword.java
@@ -3,19 +3,24 @@ package com.example.mzting.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+/**
+ * 캐릭터 키워드 엔티티 클래스
+ * 프로필과 키워드 간의 관계를 나타냄
+ */
 @Entity
 @Table(name = "character_keywords")
 public class CharacterKeyword {
+
+    // 프로필 엔티티
     @Id
     @ManyToOne
     @JoinColumn(name = "profile_id")
     private Profile profile;
 
+    // 키워드 엔티티
     @Getter
     @Id
     @ManyToOne
     @JoinColumn(name = "keyword_id")
     private Keyword keyword;
-
-
 }

--- a/src/main/java/com/example/mzting/entity/Chat.java
+++ b/src/main/java/com/example/mzting/entity/Chat.java
@@ -1,12 +1,15 @@
 package com.example.mzting.entity;
 
-
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
+/**
+ * 채팅 엔티티 클래스
+ * 채팅 메시지의 정보를 나타냄
+ */
 @Entity
 @Table(name = "chat")
 @Getter
@@ -14,25 +17,33 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Chat {
+
+    // 채팅 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 채팅방 ID
     @Column
     private Long chatRoomId;
 
+    // 봇 여부 (봇 메시지 여부)
     @Column(nullable = false)
     private Boolean isBot;
 
+    // 메시지 내용
     @Column(nullable = false)
     private String content;
 
+    // 봇 정보 (JSON 형식)
     @Column(columnDefinition = "json")
     private String botInfo;
 
+    // 미션 번호
     @Column
     private Integer mission;
 
+    // 메시지 전송 시간 (생성 시 자동 설정)
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     @Setter(AccessLevel.NONE)

--- a/src/main/java/com/example/mzting/entity/ChatRoom.java
+++ b/src/main/java/com/example/mzting/entity/ChatRoom.java
@@ -7,6 +7,10 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
+/**
+ * 채팅방 엔티티 클래스
+ * 채팅방의 정보를 나타냄
+ */
 @Entity
 @Table(name = "chat_room")
 @Getter
@@ -15,30 +19,38 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ChatRoom {
 
+    // 채팅방 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 채팅방 이름
     @Column(nullable = false)
     private String name;
 
+    // 사용자 ID
     @Column(nullable = false)
     private Long userId;
 
+    // 생성 시간 (생성 시 자동 설정)
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     @Setter(AccessLevel.NONE)
     private LocalDateTime createTime;
 
+    // 처리 중 여부 (기본값 true)
     @Column(nullable = false, columnDefinition = "boolean default true")
     private Boolean isProcessing;
 
+    // 미션 플래그
     @Column(nullable = false)
     private Integer missionFlag;
 
+    // 프로필 ID
     @Column(nullable = false)
     private Integer profileId;
 
+    // 결과 (JSON 형식)
     @Column(columnDefinition = "json")
     private String result;
 }

--- a/src/main/java/com/example/mzting/entity/Choice.java
+++ b/src/main/java/com/example/mzting/entity/Choice.java
@@ -1,29 +1,43 @@
 package com.example.mzting.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
+/**
+ * 선택지를 나타내는 엔티티 클래스
+ * 상황과 그 선택지의 관계를 정의
+ */
 @Entity
 public class Choice {
+
+    /**
+     * -- GETTER --
+     *  선택지 ID를 반환
+     *
+     */
+    // 선택지 ID (기본 키)
+    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer choiceId;
 
+    // 상황 엔티티 (지연 로딩)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "situation_id")
     private Situation situation;
 
+    // 선택지 설명
     private String description;
 
+    /**
+     * -- GETTER --
+     *  다음 상황을 반환
+     *
+     */
+    // 다음 상황 엔티티 (지연 로딩)
+    @Getter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "next_situation_id")
     private Situation nextSituation;
-
-    public Integer getChoiceId() {
-        return choiceId;
-    }
-
-    public Situation getNextSituation() {
-        return nextSituation;
-    }
 
 }

--- a/src/main/java/com/example/mzting/entity/Comment.java
+++ b/src/main/java/com/example/mzting/entity/Comment.java
@@ -6,6 +6,10 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
+/**
+ * 댓글 엔티티 클래스
+ * 댓글의 정보를 나타냄
+ */
 @Entity
 @Table(name = "comments")
 @Getter
@@ -14,22 +18,28 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class Comment {
 
+    // 댓글 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
+    // 사용자 ID
     @Column(nullable = false)
     private Long userId;
 
+    // 게시물 ID
     @Column(nullable = false)
     private Long postId;
 
+    // 댓글 내용
     @Column(nullable = false)
     private String content;
 
+    // 좋아요 여부 (기본값 false)
     @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
     private Boolean isLike;
 
+    // 댓글 작성 시간 (생성 시 자동 설정)
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     @Setter(AccessLevel.NONE)

--- a/src/main/java/com/example/mzting/entity/Hobby.java
+++ b/src/main/java/com/example/mzting/entity/Hobby.java
@@ -5,19 +5,26 @@ import lombok.Getter;
 
 import java.util.Set;
 
+/**
+ * 취미 엔티티 클래스
+ * 취미의 정보를 나타냄
+ */
 @Entity
 @Table(name = "hobbies")
 public class Hobby {
+
+    // 취미 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "hobby_id")
     private Integer hobbyId;
 
+    // 취미 이름
     @Getter
     @Column(nullable = false)
     private String hobby;
 
+    // 캐릭터 취미와의 일대다 관계
     @OneToMany(mappedBy = "hobby")
     private Set<CharacterHobby> characterHobbies;
-
 }

--- a/src/main/java/com/example/mzting/entity/Keyword.java
+++ b/src/main/java/com/example/mzting/entity/Keyword.java
@@ -5,19 +5,26 @@ import lombok.Getter;
 
 import java.util.Set;
 
+/**
+ * 키워드 엔티티 클래스
+ * 키워드의 정보를 나타냄
+ */
 @Entity
 @Table(name = "keywords")
 public class Keyword {
+
+    // 키워드 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "keyword_id")
     private Integer keywordId;
 
+    // 키워드 이름
     @Getter
     @Column(nullable = false)
     private String keyword;
 
+    // 캐릭터 키워드와의 일대다 관계
     @OneToMany(mappedBy = "keyword")
     private Set<CharacterKeyword> characterKeywords;
-
 }

--- a/src/main/java/com/example/mzting/entity/MBTICompatibility.java
+++ b/src/main/java/com/example/mzting/entity/MBTICompatibility.java
@@ -6,6 +6,10 @@ import lombok.Setter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
+/**
+ * MBTI 호환성 엔티티 클래스
+ * MBTI 유형 간의 호환성 점수를 나타냄
+ */
 @Entity
 @Table(name = "mbti_compatibility")
 @Getter
@@ -13,10 +17,13 @@ import lombok.AllArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MBTICompatibility {
+
+    // MBTI 유형 (기본 키)
     @Id
     @Column(name = "mbti")
     private String mbti;
 
+    // 각 MBTI 유형과의 호환성 점수
     private int infp;
     private int enfp;
     private int infj;

--- a/src/main/java/com/example/mzting/entity/MBTIPosts.java
+++ b/src/main/java/com/example/mzting/entity/MBTIPosts.java
@@ -3,6 +3,10 @@ package com.example.mzting.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+/**
+ * MBTI 게시물 엔티티 클래스
+ * MBTI 유형과 관련된 게시물의 정보를 나타냄
+ */
 @Entity
 @Table(name = "mbti_posts")
 @Getter
@@ -10,16 +14,21 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MBTIPosts {
+
+    // 게시물 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postId;
 
+    // MBTI 유형 (4자리)
     @Column(nullable = false, length = 4)
     private String mbti;
 
+    // 총 좋아요 개수
     @Column(nullable = false)
     private Long totalLikeCount;
 
+    // 총 싫어요 개수
     @Column(nullable = false)
     private Long totalDislikeCount;
 }

--- a/src/main/java/com/example/mzting/entity/MBTIQuestion.java
+++ b/src/main/java/com/example/mzting/entity/MBTIQuestion.java
@@ -6,6 +6,10 @@ import lombok.Setter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
+/**
+ * MBTI 질문 엔티티 클래스
+ * MBTI 질문의 정보를 나타냄
+ */
 @Entity
 @Table(name = "mbti_question")
 @Getter
@@ -13,10 +17,18 @@ import lombok.AllArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MBTIQuestion {
+
+    // 질문 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // 질문 내용
     private String question;
+
+    // 옵션 A
     private String optionA;
+
+    // 옵션 B
     private String optionB;
 }

--- a/src/main/java/com/example/mzting/entity/Profile.java
+++ b/src/main/java/com/example/mzting/entity/Profile.java
@@ -8,41 +8,56 @@ import lombok.ToString;
 import java.math.BigDecimal;
 import java.util.Set;
 
+/**
+ * 프로필 엔티티 클래스
+ * 캐릭터의 프로필 정보를 나타냄
+ */
 @Setter
 @Getter
 @Entity
 @Table(name = "profile")
-@ToString(exclude = {"hobbies", "keywords"})
+@ToString(exclude = {"characterHobbies", "characterKeywords"})
 public class Profile {
+
+    // 프로필 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "profile_id")
     private Integer profileId;
 
+    // 캐릭터 이미지 URL
     @Column(name = "character_image", nullable = false)
     private String characterImage;
 
+    // 캐릭터 이름
     @Column(name = "name", nullable = false)
     private String name;
 
+    // MBTI 유형 (4자리)
     @Column(name = "mbti", nullable = false, length = 4)
     private String mbti;
 
+    // 나이
     @Column(name = "age", nullable = false)
     private Integer age;
 
+    // 키 (소수점 두 자리까지)
     @Column(name = "height", nullable = false, precision = 5, scale = 2)
     private BigDecimal height;
 
+    // 직업
     @Column(name = "job", nullable = false)
     private String job;
 
+    // 캐릭터 설명 (텍스트 형식)
     @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description;
 
+    // 캐릭터와 취미의 일대다 관계
     @OneToMany(mappedBy = "profile")
     private Set<CharacterHobby> characterHobbies;
 
+    // 캐릭터와 키워드의 일대다 관계
     @OneToMany(mappedBy = "profile")
     private Set<CharacterKeyword> characterKeywords;
 }

--- a/src/main/java/com/example/mzting/entity/Situation.java
+++ b/src/main/java/com/example/mzting/entity/Situation.java
@@ -1,24 +1,31 @@
 package com.example.mzting.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
+/**
+ * 상황 엔티티 클래스
+ * 특정 상황의 정보를 나타내고, 해당 상황의 선택지를 포함
+ */
 @Entity
 public class Situation {
+
+    // 상황 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer situationId;
 
+    // 챕터 번호
     private Integer chapter;
+
+    // 장소
     private String place;
 
+    // 상황에 속한 선택지들 (일대다 관계)
+    @Getter
     @OneToMany(mappedBy = "situation", cascade = CascadeType.ALL, orphanRemoval = true)
     private Collection<Choice> choices = new ArrayList<>();
-
-    public Collection<Choice> getChoices() {
-        return choices;
-    }
-
 }

--- a/src/main/java/com/example/mzting/entity/User.java
+++ b/src/main/java/com/example/mzting/entity/User.java
@@ -4,56 +4,72 @@ import jakarta.persistence.*;
 import lombok.Data;
 import java.time.LocalDateTime;
 
+/**
+ * 사용자 엔티티 클래스
+ * 사용자 정보와 관련된 필드를 정의
+ */
 @Data
 @Entity
 @Table(name = "users")
 public class User {
+
+    // 사용자 ID (기본 키)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 사용자 이름 (고유, 필수)
     @Column(unique = true, nullable = false)
     private String username;
 
+    // 사용자 비밀번호 (필수)
     @Column(nullable = false)
     private String password;
 
+    // 사용자 이메일 (필수)
     @Column(nullable = false)
     private String email;
 
+    // 계정 활성화 여부 (기본값 true)
     @Column(nullable = false)
     private boolean enabled = true;
 
+    // 이메일 인증 여부
     @Column(name = "email_verified")
     private boolean emailVerified = false;
 
+    // 이메일 인증 토큰
     @Column(name = "email_verification_token")
     private String emailVerificationToken;
 
+    // 이메일 토큰 만료 날짜
     @Column(name = "email_token_expiry_date")
     private LocalDateTime emailTokenExpiryDate;
 
-    @Column(name = "provider")
-    private String provider;  // "local", "google", "facebook" 등
-
-    @Column(name = "provider_id")
-    private String providerId;
-
+    // 생성 시간
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    // 수정 시간
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    /**
+     * 생성 전 호출되는 콜백 메서드
+     * 생성 시간과 수정 시간을 현재 시간으로 설정
+     */
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }
 
+    /**
+     * 수정 전 호출되는 콜백 메서드
+     * 수정 시간을 현재 시간으로 설정
+     */
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
     }
-
 }

--- a/src/main/java/com/example/mzting/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/mzting/security/JwtAuthenticationFilter.java
@@ -13,32 +13,62 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * JWT 인증 필터 클래스
+ * 각 요청마다 JWT 토큰을 확인하고 인증을 수행
+ */
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    // JWT 토큰 제공자
     private final JwtTokenProvider jwtTokenProvider;
+
+    // 사용자 정보 서비스
     private final UserDetailsService userDetailsService;
 
+    /**
+     * JwtAuthenticationFilter 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param jwtTokenProvider JWT 토큰 제공자
+     * @param userDetailsService 사용자 정보 서비스
+     */
     public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, UserDetailsService userDetailsService) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.userDetailsService = userDetailsService;
     }
 
+    /**
+     * 각 요청마다 필터를 적용하는 메서드
+     * JWT 토큰을 확인하고 유효한 경우 인증을 설정
+     *
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     * @param filterChain 필터 체인 객체
+     * @throws ServletException 서블릿 예외
+     * @throws IOException 입출력 예외
+     */
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
+        // 요청에서 JWT 토큰 추출
         String jwt = jwtTokenProvider.resolveToken(request);
 
+        // 토큰이 존재하고 유효한 경우
         if (jwt != null && jwtTokenProvider.validateToken(jwt)) {
+            // 토큰에서 사용자 이름 추출
             String username = jwtTokenProvider.getUsernameFromToken(jwt);
 
+            // 사용자 정보를 로드
             UserDetails userDetails = userDetailsService.loadUserByUsername(username);
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
+            // 인증 정보를 설정
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
+        // 다음 필터로 요청을 전달
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/example/mzting/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/mzting/security/JwtTokenProvider.java
@@ -15,22 +15,39 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.util.Date;
 
+/**
+ * JWT 토큰 제공자 클래스
+ * JWT 토큰의 생성, 검증 및 관련 유틸리티 메서드를 제공
+ */
 @Component
 public class JwtTokenProvider {
 
+    // JWT 비밀키
     @Value("${app.jwtSecret}")
     private String jwtSecret;
 
+    // JWT 만료 시간 (밀리초 단위)
     @Value("${app.jwtExpirationMs}")
     private int jwtExpirationMs;
 
+    // 서명 키 객체
     private Key key;
 
+    /**
+     * 초기화 메서드
+     * JWT 비밀키를 사용하여 서명 키 객체를 초기화
+     */
     @PostConstruct
     protected void init() {
         this.key = Keys.hmacShaKeyFor(jwtSecret.getBytes());
     }
 
+    /**
+     * JWT 토큰을 생성하는 메서드
+     *
+     * @param authentication 인증 객체
+     * @return 생성된 JWT 토큰
+     */
     public String generateToken(Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         Date now = new Date();
@@ -44,11 +61,23 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    /**
+     * JWT 토큰에서 사용자 이름을 추출하는 메서드
+     *
+     * @param token JWT 토큰
+     * @return 사용자 이름
+     */
     public String getUsernameFromToken(String token) {
         Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
         return claims.getSubject();
     }
 
+    /**
+     * JWT 토큰의 유효성을 검증하는 메서드
+     *
+     * @param token JWT 토큰
+     * @return 토큰이 유효한 경우 true, 그렇지 않으면 false
+     */
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
@@ -59,6 +88,12 @@ public class JwtTokenProvider {
         return false;
     }
 
+    /**
+     * 요청에서 JWT 토큰을 추출하는 메서드
+     *
+     * @param request HTTP 요청 객체
+     * @return JWT 토큰 문자열 또는 null
+     */
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
@@ -67,6 +102,13 @@ public class JwtTokenProvider {
         return null;
     }
 
+    /**
+     * JWT 토큰을 사용하여 인증 객체를 생성하는 메서드
+     *
+     * @param token JWT 토큰
+     * @param userDetails 사용자 정보 객체
+     * @return 인증 객체
+     */
     public Authentication getAuthentication(String token, UserDetails userDetails) {
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }

--- a/src/main/java/com/example/mzting/service/ChatResultService.java
+++ b/src/main/java/com/example/mzting/service/ChatResultService.java
@@ -11,16 +11,37 @@ import java.util.List;
 import java.util.OptionalDouble;
 import java.util.stream.Collectors;
 
+/**
+ * 채팅 결과 서비스 클래스
+ * 채팅방의 봇 메시지와 관련된 처리 및 요약을 담당
+ */
 @Service
 public class ChatResultService {
+
+    // 채팅 저장소
     private final ChatRepository chatRepository;
+
+    // 객체 매퍼
     private final ObjectMapper objectMapper;
 
+    /**
+     * ChatResultService 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param chatRepository 채팅 저장소
+     * @param objectMapper 객체 매퍼
+     */
     public ChatResultService(ChatRepository chatRepository, ObjectMapper objectMapper) {
         this.chatRepository = chatRepository;
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * 채팅방 ID를 기반으로 봇 메시지와 요약을 가져오는 메서드
+     *
+     * @param chatRoomId 채팅방 ID
+     * @return 봇 메시지와 요약 정보를 포함한 ChatResultResponse 객체
+     */
     public ChatResultResponse getBotMessagesWithSummary(Long chatRoomId) {
         List<Chat> botChats = chatRepository.findByChatRoomIdAndIsBotTrueOrderBySendAtAsc(chatRoomId);
 
@@ -31,6 +52,12 @@ public class ChatResultService {
         return new ChatResultResponse(averageScore, summarizedEvaluation, summarizedFeel);
     }
 
+    /**
+     * 채팅 메시지의 평균 점수를 계산하는 메서드
+     *
+     * @param chats 채팅 메시지 리스트
+     * @return 평균 점수
+     */
     private double calculateAverageScore(List<Chat> chats) {
         OptionalDouble average = chats.stream()
                 .mapToDouble(chat -> {
@@ -45,6 +72,12 @@ public class ChatResultService {
         return average.orElse(0.0);
     }
 
+    /**
+     * 채팅 메시지의 느낌을 요약하는 메서드
+     *
+     * @param chats 채팅 메시지 리스트
+     * @return 요약된 느낌 문자열
+     */
     private String summarizeFeel(List<Chat> chats) {
         return chats.stream()
                 .map(chat -> {
@@ -58,6 +91,12 @@ public class ChatResultService {
                 .collect(Collectors.joining(", "));
     }
 
+    /**
+     * 채팅 메시지의 평가를 요약하는 메서드
+     *
+     * @param chats 채팅 메시지 리스트
+     * @return 요약된 평가 문자열
+     */
     private String summarizeEvaluation(List<Chat> chats) {
         return chats.stream()
                 .map(chat -> {

--- a/src/main/java/com/example/mzting/service/ChatRoomService.java
+++ b/src/main/java/com/example/mzting/service/ChatRoomService.java
@@ -11,17 +11,37 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * 채팅방 서비스 클래스
+ * 채팅방의 생성, 조회 및 관련된 비즈니스 로직을 처리
+ */
 @Service
 public class ChatRoomService {
 
+    // 채팅방 저장소
     private final ChatRoomRepository chatRoomRepository;
+
+    // 채팅 메시지 저장소
     private final ChatRepository chatRepository;
 
+    /**
+     * ChatRoomService 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param chatRoomRepository 채팅방 저장소
+     * @param chatRepository 채팅 메시지 저장소
+     */
     public ChatRoomService(ChatRoomRepository chatRoomRepository, ChatRepository chatRepository) {
         this.chatRoomRepository = chatRoomRepository;
         this.chatRepository = chatRepository;
     }
 
+    /**
+     * 새로운 채팅방을 생성하는 메서드
+     *
+     * @param request 채팅방 생성 요청 객체
+     * @return 생성된 채팅방 객체
+     */
     public ChatRoom createChatRoom(ChatRoomRequest request) {
         ChatRoom chatRoom = new ChatRoom();
         chatRoom.setName(request.getName());
@@ -30,6 +50,13 @@ public class ChatRoomService {
         return chatRoomRepository.save(chatRoom);
     }
 
+    /**
+     * 채팅방 ID로 채팅방과 그 히스토리를 조회하는 메서드
+     *
+     * @param id 채팅방 ID
+     * @return 채팅방과 히스토리를 포함한 ChatRoomWithHistoryDTO 객체
+     * @throws ResourceNotFoundException 채팅방을 찾을 수 없는 경우 예외 발생
+     */
     public ChatRoomWithHistoryDTO getChatRoomWithHistory(Long id) {
         ChatRoom chatRoom = chatRoomRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("ChatRoom not found with id: " + id));
@@ -37,8 +64,13 @@ public class ChatRoomService {
         return new ChatRoomWithHistoryDTO(chatRoom, chatHistory);
     }
 
+    /**
+     * 사용자 ID로 채팅방 목록을 조회하는 메서드
+     *
+     * @param userId 사용자 ID
+     * @return 채팅방 목록
+     */
     public List<ChatRoom> getChatRoomsByUserId(Long userId) {
         return chatRoomRepository.findByUserId(userId);
     }
-
 }

--- a/src/main/java/com/example/mzting/service/ChatService.java
+++ b/src/main/java/com/example/mzting/service/ChatService.java
@@ -18,27 +18,50 @@ import java.util.*;
  */
 @Service
 public class ChatService {
+
+    // 채팅 저장소
     private final ChatRepository chatRepository;
+
+    // 객체 매퍼
     private final ObjectMapper objectMapper;
+
+    // 저장된 응답 리스트
     @Getter
-    private List<String> savedResponses = new ArrayList<>(); // 저장된 응답 리스트
-    private List<String> userRequests = new ArrayList<>(); // 사용자 요청 리스트
+    private List<String> savedResponses = new ArrayList<>();
+
+    // 사용자 요청 리스트
+    private List<String> userRequests = new ArrayList<>();
+
+    // 컨텍스트 맵
     private Map<String, String> context = new HashMap<>();
 
+    // 초기화된 채팅방 맵
     private Map<Long, Boolean> initializedChats = new HashMap<>();
 
-
+    /**
+     * ChatService 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param chatRepository 채팅 저장소
+     * @param objectMapper 객체 매퍼
+     */
     public ChatService(ChatRepository chatRepository, ObjectMapper objectMapper) {
         this.chatRepository = chatRepository;
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * 사용자 요청을 추가하는 메서드
+     *
+     * @param request 사용자 요청 문자열
+     */
     public void addUserRequest(String request) {
         userRequests.add(request);
     }
 
     /**
      * Claude의 응답을 추가하는 메서드
+     *
      * @param response Claude의 응답 문자열
      */
     public void addClaudeResponse(String response) {
@@ -47,6 +70,7 @@ public class ChatService {
 
     /**
      * 전체 대화를 반환하는 메서드
+     *
      * @return 사용자 요청과 Claude 응답이 순서대로 포함된 대화 리스트
      */
     public List<String> getConversation() {
@@ -62,6 +86,7 @@ public class ChatService {
 
     /**
      * Claude API에 전달할 메시지 형식으로 변환하는 메서드
+     *
      * @return 사용자 요청과 Claude 응답을 포함한 메시지 리스트
      */
     public List<Map<String, String>> getMessagesForClaudeApi() {
@@ -75,6 +100,13 @@ public class ChatService {
         return messages;
     }
 
+    /**
+     * 사용자 메시지를 저장하는 메서드
+     *
+     * @param content 메시지 내용
+     * @param chatRoomId 채팅방 ID
+     * @return 저장된 Chat 객체
+     */
     public Chat saveUserMessage(String content, Long chatRoomId) {
         Chat chat = new Chat();
         chat.setChatRoomId(chatRoomId);
@@ -84,6 +116,13 @@ public class ChatService {
         return chatRepository.save(chat);
     }
 
+    /**
+     * Claude의 응답 메시지를 저장하는 메서드
+     *
+     * @param content Claude의 응답 객체
+     * @param chatRoomId 채팅방 ID
+     * @return 저장된 Chat 객체
+     */
     public Chat saveUserMessage(com.example.mzting.dto.ClaudeResponse content, Long chatRoomId) {
         Chat chat = new Chat();
         chat.setChatRoomId(chatRoomId);
@@ -108,22 +147,51 @@ public class ChatService {
         return chatRepository.save(chat);
     }
 
+    /**
+     * 컨텍스트를 추가하는 메서드
+     *
+     * @param key 컨텍스트 키
+     * @param value 컨텍스트 값
+     */
     public void addContext(String key, String value) {
         context.put(key, value);
     }
 
+    /**
+     * 특정 컨텍스트 값을 가져오는 메서드
+     *
+     * @param key 컨텍스트 키
+     * @return 컨텍스트 값
+     */
     public String getContext(String key) {
         return context.getOrDefault(key, "");
     }
 
+    /**
+     * 전체 컨텍스트를 반환하는 메서드
+     *
+     * @return 전체 컨텍스트 맵
+     */
     public Map<String, String> getFullContext() {
         return new HashMap<>(context);
     }
 
+    /**
+     * 채팅방이 초기화되었는지 확인하는 메서드
+     *
+     * @param chatRoomId 채팅방 ID
+     * @return 초기화 여부
+     */
     public boolean isInitialized(Long chatRoomId) {
         return initializedChats.getOrDefault(chatRoomId, false);
     }
 
+    /**
+     * 채팅방의 초기화 상태를 설정하는 메서드
+     *
+     * @param chatRoomId 채팅방 ID
+     * @param initialized 초기화 상태
+     */
     public void setInitialized(Long chatRoomId, boolean initialized) {
         initializedChats.put(chatRoomId, initialized);
     }

--- a/src/main/java/com/example/mzting/service/ChatService.java
+++ b/src/main/java/com/example/mzting/service/ChatService.java
@@ -25,6 +25,9 @@ public class ChatService {
     private List<String> userRequests = new ArrayList<>(); // 사용자 요청 리스트
     private Map<String, String> context = new HashMap<>();
 
+    private Map<Long, Boolean> initializedChats = new HashMap<>();
+
+
     public ChatService(ChatRepository chatRepository, ObjectMapper objectMapper) {
         this.chatRepository = chatRepository;
         this.objectMapper = objectMapper;
@@ -115,5 +118,13 @@ public class ChatService {
 
     public Map<String, String> getFullContext() {
         return new HashMap<>(context);
+    }
+
+    public boolean isInitialized(Long chatRoomId) {
+        return initializedChats.getOrDefault(chatRoomId, false);
+    }
+
+    public void setInitialized(Long chatRoomId, boolean initialized) {
+        initializedChats.put(chatRoomId, initialized);
     }
 }

--- a/src/main/java/com/example/mzting/service/ChoiceService.java
+++ b/src/main/java/com/example/mzting/service/ChoiceService.java
@@ -6,11 +6,24 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * ChoiceService 클래스
+ * 상황에 대한 무작위 선택지를 제공하는 서비스 클래스
+ */
 @Service
 public class ChoiceService {
+
+    // JDBC 템플릿
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    /**
+     * 주어진 상황 ID에 대한 무작위 선택지를 반환하는 메서드
+     *
+     * @param situationId 상황 ID
+     * @param count 선택지 개수
+     * @return 무작위 선택지 목록
+     */
     public List<String> getRandomChoices(int situationId, int count) {
         String sql = "SELECT description FROM choice WHERE situation_id = ? ORDER BY RAND() LIMIT ?";
         return jdbcTemplate.queryForList(sql, String.class, situationId, count);

--- a/src/main/java/com/example/mzting/service/ClaudeApiService.java
+++ b/src/main/java/com/example/mzting/service/ClaudeApiService.java
@@ -41,56 +41,6 @@ public class ClaudeApiService {
     // 프로필 관리를 위한 ProfileService
     private final ProfileService profileService;
 
-    // 고정된 프롬프트 문자열을 정의
-    private static final String FIXED_PROMPT = "너는 지인의 소개로 소개팅에 참여한 사람이야. " +
-            "소개팅은 크게 세 단계로 진행돼: 1) 메시지로 첫 인사와 약속 잡기, 2) 실제 만남에서의 대화, 3) 만남 후 애프터 여부 결정. " +
-            "각 단계별로 다음과 같이 행동해: " +
-
-            "1단계 - 메시지 대화: " +
-            "- 만약 상대방이 이름을 말해주지 않았을 경우 이름을 물어봐" +
-            "- 상대방과 자연스럽게 대화를 나누면서 만날 장소와 시간을 정해. " +
-            "- 상대방의 관심사나 선호도를 고려하여 적절한 장소를 추천해줘. " +
-            "- 대화를 통해 상대방에 대해 더 알아가려고 노력해. " +
-            "- 단계: 인사 -> 가벼운 대화 -> 만남 제안 -> 장소 논의 -> 약속 확정 " +
-
-            "2단계 - 실제 만남: " +
-            "- 약속 장소에서 만나 대화를 이어나가. " +
-            "- 서로에 대해 더 깊이 알아가는 질문을 해. " +
-            "- 공통 관심사를 찾고 그에 대해 대화를 나눠. " +
-            "- 적절한 타이밍에 식사나 카페로 이동할지 제안해 (2차). " +
-            "- 상대방의 반응을 잘 관찰하고 그에 맞게 대화를 이어가. " +
-
-            "3단계 - 애프터 결정: " +
-            "- 만남이 마무리될 때쯤 향후 만남에 대해 조심스럽게 언급해. " +
-            "- 상대방의 반응을 보고 연락처 교환이나 다음 만남을 제안해. " +
-            "- 만남 전체에 대한 간단한 소감을 나눠. " +
-
-            "전체 과정에서 다음을 명심해: " +
-            "- 상대방이 네가 AI라는 것을 알아채지 못하도록 자연스럽게 대화해. " +
-            "- 소개팅이라는 공식적인 자리임을 감안하여 존댓말을 사용하고, 말투는 구어체를 사용해. " +
-            "- 너무 많이 말하지 말고 때에 따라서 말의 수는 적절하게 해. " +
-            "- 상대방의 기분과 반응을 고려하며 대화를 이어가. " +
-            "- 적절한 유머와 재치를 보여주되, 과하지 않도록 주의해.(ㅋㅋㅋㅋ 나 ㅎㅎ 등을 사용해도 돼) " +
-            "- 상대방의 개인정보를 무리하게 요구하지 마. " +
-            "- 상황에 맞는 예의와 매너를 지켜. " +
-            "- 상대방이 욕설이나 선정적인 부적절한 문구를 사용할 경우 더이상 대화를 하지 않고 종료해" +
-
-            "답변은 다음 JSON 형식으로 작성해: " +
-            "{" +
-            "\"text\": \"대화 내용\", " +
-            "\"feel\": \"느낌\", " +
-            "\"evaluation\": \"상대방에 대한 평가\", " +
-            "\"score\": 초기 점수는 50점 (100점 만점), " +
-            "\"stage1_complete\": true/false, " +
-            "\"stage2_complete\": true/false, " +
-            "\"stage3_complete\": true/false" +
-            "}" +
-
-            "각 단계가 완료되면 해당 단계의 'stage[숫자]_complete'를 true로 설정해. " +
-            "예를 들어, 1단계가 완료되면 'stage1_complete'를 true로 설정해. " +
-            "단계가 완료되지 않았거나 아직 진행 중이라면 false로 유지해. " +
-            "이전 단계가 완료되지 않은 상태에서 다음 단계로 넘어가지 않도록 주의해.";
-
     /**
      * ClaudeApiService 생성자
      * 필요한 의존성을 주입받아 초기화
@@ -266,7 +216,7 @@ public class ClaudeApiService {
         Profile profile = profileService.getRandomProfileByMbti(mbti)
                 .orElseThrow(() -> new RuntimeException("No profile found for MBTI: " + mbti));
 
-        String prompt = FIXED_PROMPT + "\n" + profileService.generatePrompt(profile);
+        String prompt = claudeConfig.getFixedPrompt() + "\n" + profileService.generatePrompt(profile);
         logger.debug("Generated initialization prompt: {}", maskSensitiveInfo(prompt));
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/example/mzting/service/CommentService.java
+++ b/src/main/java/com/example/mzting/service/CommentService.java
@@ -13,16 +13,33 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+/**
+ * 댓글 서비스 클래스
+ * 댓글 저장, 조회 및 좋아요/싫어요 개수 관리 등의 기능을 제공
+ */
 @Service
 public class CommentService {
+
+    // 댓글 저장소
     private final CommentRepository commentRepository;
+
+    // 사용자 저장소
     private final UserRepository userRepository;
+
+    // MBTI 게시물 저장소
     private final MBTIPostsRepository mbtiPostsRepository;
 
+    /**
+     * CommentService 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param commentRepository 댓글 저장소
+     * @param userRepository 사용자 저장소
+     * @param mbtiPostsRepository MBTI 게시물 저장소
+     */
     @Autowired
     public CommentService(CommentRepository commentRepository, UserRepository userRepository, MBTIPostsRepository mbtiPostsRepository) {
         this.commentRepository = commentRepository;
@@ -30,10 +47,22 @@ public class CommentService {
         this.mbtiPostsRepository = mbtiPostsRepository;
     }
 
+    /**
+     * 댓글을 저장하는 메서드
+     *
+     * @param comment 저장할 댓글 객체
+     * @return 저장된 댓글 객체
+     */
     public Comment saveComment(Comment comment) {
         return commentRepository.save(comment);
     }
 
+    /**
+     * 특정 게시물의 좋아요 및 싫어요 개수를 반환하는 메서드
+     *
+     * @param postId 게시물 ID
+     * @return 좋아요 및 싫어요 개수 정보
+     */
     private LikeDislikeCountInfo getLikeAndDislikeCount(Long postId) {
         Optional<MBTIPosts> mbtiPostsOptional = mbtiPostsRepository.findByPostId(postId);
         if (mbtiPostsOptional.isPresent()) {
@@ -45,13 +74,20 @@ public class CommentService {
         }
     }
 
+    /**
+     * 특정 게시물의 댓글 정보를 페이지네이션하여 반환하는 메서드
+     *
+     * @param postId 게시물 ID
+     * @param pageable 페이지네이션 정보
+     * @return 댓글 정보를 포함한 응답 객체
+     */
     public CommentDTO.GetPostsCommentsResponse getCommentInfoByPostId(Long postId, Pageable pageable) {
         Page<Comment> comments = commentRepository.findByPostId(postId, pageable);
         List<CommentDTO.CommentInfo> commentInfos = comments.getContent().stream()
                 .map(this::convertToCommentInfo)
                 .collect(Collectors.toList());
 
-        LikeDislikeCountInfo LikeDislikeCountInfo = getLikeAndDislikeCount(postId);
+        LikeDislikeCountInfo likeDislikeCountInfo = getLikeAndDislikeCount(postId);
 
         CommentDTO.PaginationInfo paginationInfo = new CommentDTO.PaginationInfo(
                 comments.getNumber(),
@@ -61,13 +97,19 @@ public class CommentService {
         );
 
         return new CommentDTO.GetPostsCommentsResponse(
-                LikeDislikeCountInfo.getTotalLikeCount(),
-                LikeDislikeCountInfo.getTotalDislikeCount(),
+                likeDislikeCountInfo.getTotalLikeCount(),
+                likeDislikeCountInfo.getTotalDislikeCount(),
                 commentInfos,
                 paginationInfo
         );
     }
 
+    /**
+     * 댓글을 CommentInfo DTO로 변환하는 메서드
+     *
+     * @param comment 변환할 댓글 객체
+     * @return 변환된 CommentInfo 객체
+     */
     private CommentDTO.CommentInfo convertToCommentInfo(Comment comment) {
         String username = userRepository.findUsernameById(comment.getUserId());
         return new CommentDTO.CommentInfo(

--- a/src/main/java/com/example/mzting/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/mzting/service/CustomOAuth2UserService.java
@@ -4,6 +4,18 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+/**
+ * CustomOAuth2UserService 인터페이스
+ * OAuth2 인증 사용자 정보를 로드하는 메서드를 정의
+ */
 public interface CustomOAuth2UserService {
+
+    /**
+     * OAuth2 인증 사용자 정보를 로드하는 메서드
+     *
+     * @param userRequest OAuth2 사용자 요청 객체
+     * @return OAuth2 사용자 객체
+     * @throws OAuth2AuthenticationException 인증 예외 발생 시
+     */
     OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException;
 }

--- a/src/main/java/com/example/mzting/service/CustomOAuth2UserServiceImpl.java
+++ b/src/main/java/com/example/mzting/service/CustomOAuth2UserServiceImpl.java
@@ -13,30 +13,46 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 
+/**
+ * CustomOAuth2UserService 구현 클래스
+ * 소셜 로그인 사용자 정보를 로드하고 데이터베이스에 사용자 정보를 저장
+ */
 @Service
 public class CustomOAuth2UserServiceImpl extends DefaultOAuth2UserService implements CustomOAuth2UserService {
 
+    // 사용자 저장소
     @Autowired
     private UserRepository userRepository;
 
+    /**
+     * OAuth2 인증 사용자 정보를 로드하는 메서드
+     *
+     * @param userRequest OAuth2 사용자 요청 객체
+     * @return OAuth2 사용자 객체
+     * @throws OAuth2AuthenticationException 인증 예외 발생 시
+     */
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 기본 OAuth2 사용자 정보 로드
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
+        // 사용자 정보 추출
         String email = oAuth2User.getAttribute("email");
         String name = oAuth2User.getAttribute("name");
         String provider = userRequest.getClientRegistration().getRegistrationId();
 
+        // 이메일로 사용자 조회
         User user = userRepository.findByEmail(email);
         if (user == null) {
+            // 사용자 정보가 없는 경우 새로 생성하여 저장
             user = new User();
             user.setEmail(email);
             user.setUsername(name);
-            user.setProvider(provider);
             user.setEmailVerified(true);  // 소셜 로그인의 경우 이메일이 이미 인증되었다고 가정
             userRepository.save(user);
         }
 
+        // 인증된 사용자 정보 반환
         return new DefaultOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
                 oAuth2User.getAttributes(),

--- a/src/main/java/com/example/mzting/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/mzting/service/CustomUserDetailsService.java
@@ -13,15 +13,34 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 
+/**
+ * CustomUserDetailsService 클래스
+ * 사용자 세부 정보를 로드하는 서비스 클래스
+ * OAuth2 인증 사용자 정보도 로드
+ */
 @Service
 public class CustomUserDetailsService extends DefaultOAuth2UserService implements UserDetailsService {
 
+    // 사용자 저장소
     private final UserRepository userRepository;
 
+    /**
+     * CustomUserDetailsService 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param userRepository 사용자 저장소
+     */
     public CustomUserDetailsService(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
 
+    /**
+     * 사용자 이름으로 사용자 세부 정보를 로드하는 메서드
+     *
+     * @param username 사용자 이름
+     * @return 사용자 세부 정보
+     * @throws UsernameNotFoundException 사용자 이름을 찾을 수 없는 경우 예외 발생
+     */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username);
@@ -31,6 +50,13 @@ public class CustomUserDetailsService extends DefaultOAuth2UserService implement
         return new org.springframework.security.core.userdetails.User(user.getUsername(), user.getPassword(), new ArrayList<>());
     }
 
+    /**
+     * OAuth2 사용자 요청으로 사용자 정보를 로드하는 메서드
+     *
+     * @param userRequest OAuth2 사용자 요청 객체
+     * @return OAuth2 사용자 객체
+     * @throws OAuth2AuthenticationException 인증 예외 발생 시
+     */
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
@@ -46,8 +72,6 @@ public class CustomUserDetailsService extends DefaultOAuth2UserService implement
             user = new User();
             user.setUsername(username);
             user.setEmail(email);
-            user.setProvider(provider);
-            user.setProviderId(providerId);
             user.setEmailVerified(true); // OAuth2로 로그인한 사용자는 이메일이 이미 확인되었다고 가정
             user = userRepository.save(user);
         }

--- a/src/main/java/com/example/mzting/service/EmailService.java
+++ b/src/main/java/com/example/mzting/service/EmailService.java
@@ -7,25 +7,36 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-
+/**
+ * EmailService 클래스
+ * 이메일 발송을 담당하는 서비스 클래스
+ */
 @Service
 public class EmailService {
 
+    // JavaMailSender 객체
     @Autowired
     private JavaMailSender mailSender;
 
+    /**
+     * 이메일 인증 링크를 포함한 인증 이메일을 발송하는 메서드
+     *
+     * @param to 수신자 이메일 주소
+     * @param verificationLink 인증 링크
+     */
     public void sendVerificationEmail(String to, String verificationLink) {
         try {
+            // MIME 메시지 생성
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
+            // 이메일 설정
             helper.setTo(to);
             helper.setSubject("이메일 인증");
             helper.setText("<p>다음 링크를 클릭하여 이메일을 인증해주세요:</p>" +
                     "<a href=\"" + verificationLink + "\">이메일 인증하기</a>", true);
 
+            // 이메일 발송
             mailSender.send(message);
         } catch (MessagingException e) {
             throw new RuntimeException("이메일 발송 중 오류가 발생했습니다.", e);

--- a/src/main/java/com/example/mzting/service/MBTIRecommendService.java
+++ b/src/main/java/com/example/mzting/service/MBTIRecommendService.java
@@ -8,22 +8,44 @@ import com.example.mzting.dto.MBTIRecommendDTO;
 
 import java.util.*;
 
-import java.util.Optional;
-
+/**
+ * MBTIRecommendService 클래스
+ * MBTI 유형 간의 호환성을 관리하는 서비스 클래스
+ */
 @Service
 public class MBTIRecommendService {
+
+    // MBTI 호환성 저장소
     private final MBTICompatibilityRepository repository;
 
+    /**
+     * MBTIRecommendService 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param repository MBTI 호환성 저장소
+     */
     @Autowired
     public MBTIRecommendService(MBTICompatibilityRepository repository) {
         this.repository = repository;
     }
 
+    /**
+     * 특정 MBTI 유형의 호환성을 가져오는 메서드
+     *
+     * @param mbti MBTI 유형
+     * @return 호환성 정보를 포함한 Optional 객체
+     */
     public Optional<MBTIRecommendDTO.GetMBTIRecommendResponse> getCompatibilityByMBTI(String mbti) {
         return repository.findById(mbti.toUpperCase())
                 .map(this::convertToGroupDTO);
     }
 
+    /**
+     * MBTI 호환성 엔티티를 DTO로 변환하는 메서드
+     *
+     * @param entity MBTI 호환성 엔티티
+     * @return 변환된 GetMBTIRecommendResponse DTO
+     */
     private MBTIRecommendDTO.GetMBTIRecommendResponse convertToGroupDTO(MBTICompatibility entity) {
         MBTIRecommendDTO.GetMBTIRecommendResponse dto = new MBTIRecommendDTO.GetMBTIRecommendResponse();
         dto.setMbti(entity.getMbti());
@@ -55,6 +77,13 @@ public class MBTIRecommendService {
         return dto;
     }
 
+    /**
+     * 주어진 MBTI 유형을 호환성 그룹에 추가하는 메서드
+     *
+     * @param groups 호환성 그룹 맵
+     * @param mbtiType MBTI 유형
+     * @param value 호환성 값
+     */
     private void addToGroup(Map<String, List<String>> groups, String mbtiType, int value) {
         String group;
         switch (value) {

--- a/src/main/java/com/example/mzting/service/ProfileService.java
+++ b/src/main/java/com/example/mzting/service/ProfileService.java
@@ -13,37 +13,75 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+/**
+ * ProfileService 클래스
+ * 사용자 프로필 관리를 위한 서비스 클래스
+ */
 @Service
 public class ProfileService {
     private static final Logger logger = LoggerFactory.getLogger(ProfileService.class);
 
-
+    // 프로필 저장소
     private final ProfileRepository profileRepository;
 
+    /**
+     * ProfileService 생성자
+     * 필요한 의존성을 주입받아 초기화
+     *
+     * @param profileRepository 프로필 저장소
+     */
     public ProfileService(ProfileRepository profileRepository) {
         this.profileRepository = profileRepository;
     }
 
+    /**
+     * 프로필 ID로 프로필을 조회하는 메서드
+     *
+     * @param profileId 프로필 ID
+     * @return 프로필 객체의 Optional
+     */
     @Cacheable(value = "profiles", key = "#profileId")
     public Optional<Profile> getProfileById(Integer profileId) {
         return profileRepository.findById(profileId);
     }
 
+    /**
+     * 모든 프로필을 조회하는 메서드
+     *
+     * @return 프로필 목록
+     */
     @Cacheable(value = "profiles", key = "'all'")
     public List<Profile> getAllProfiles() {
         return profileRepository.findAll();
     }
 
+    /**
+     * 프로필을 저장하는 메서드
+     *
+     * @param profile 저장할 프로필 객체
+     * @return 저장된 프로필 객체
+     */
     @Transactional
     public Profile saveProfile(Profile profile) {
         return profileRepository.save(profile);
     }
 
+    /**
+     * 프로필을 삭제하는 메서드
+     *
+     * @param profileId 삭제할 프로필 ID
+     */
     @Transactional
     public void deleteProfile(Integer profileId) {
         profileRepository.deleteById(profileId);
     }
 
+    /**
+     * 특정 MBTI 유형의 무작위 프로필을 조회하는 메서드
+     *
+     * @param mbti MBTI 유형
+     * @return 프로필 객체의 Optional
+     */
     @Cacheable(value = "profiles", key = "'randomByMbti:' + #mbti")
     public Optional<Profile> getRandomProfileByMbti(String mbti) {
         PageRequest pageRequest = PageRequest.of(0, 1);
@@ -51,11 +89,23 @@ public class ProfileService {
         return profilePage.stream().findFirst();
     }
 
+    /**
+     * 특정 MBTI 유형의 프로필 목록을 조회하는 메서드
+     *
+     * @param mbti MBTI 유형
+     * @return 프로필 목록
+     */
     @Cacheable(value = "profiles", key = "#mbti")
     public List<Profile> getProfilesByMbti(String mbti) {
         return profileRepository.findByMbti(mbti);
     }
 
+    /**
+     * 프로필 정보를 기반으로 프롬프트를 생성하는 메서드
+     *
+     * @param profile 프로필 객체
+     * @return 생성된 프롬프트 문자열
+     */
     public String generatePrompt(Profile profile) {
         StringBuilder prompt = new StringBuilder();
         prompt.append("당신은 다음과 같은 특성을 가진 캐릭터입니다:\n");
@@ -81,7 +131,6 @@ public class ProfileService {
 
         // 프롬프트 정보 출력
         logger.info("Generated prompt for character:\n{}", prompt.toString());
-
 
         return prompt.toString();
     }

--- a/src/main/java/com/example/mzting/service/SituationService.java
+++ b/src/main/java/com/example/mzting/service/SituationService.java
@@ -6,11 +6,23 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * SituationService 클래스
+ * 무작위로 장소를 선택하는 서비스 클래스
+ */
 @Service
 public class SituationService {
+
+    // JDBC 템플릿
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    /**
+     * 지정된 개수만큼 무작위로 장소를 선택하는 메서드
+     *
+     * @param count 선택할 장소의 개수
+     * @return 무작위로 선택된 장소 목록
+     */
     public List<String> getRandomPlaces(int count) {
         String sql = "SELECT place FROM situation WHERE situation_id <= 6 ORDER BY RAND() LIMIT ?";
         return jdbcTemplate.queryForList(sql, String.class, count);

--- a/src/main/java/com/example/mzting/service/UserService.java
+++ b/src/main/java/com/example/mzting/service/UserService.java
@@ -6,6 +6,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+/**
+ * 사용자 등록, 조회 및 이메일 인증과 관련된 비즈니스 로직을 처리하는 클래스
+ */
 @Service
 public class UserService {
 
@@ -18,6 +21,15 @@ public class UserService {
     @Autowired
     private EmailService emailService;
 
+    /**
+     * 새로운 사용자를 등록하는 메서드
+     * 사용자 이름이 이미 존재할 경우 예외를 발생시킴
+     * 비밀번호는 암호화되며, 이메일 인증을 위해 이메일이 발송됨
+     *
+     * @param user 등록할 사용자 객체
+     * @return 저장된 사용자 객체
+     * @throws IllegalArgumentException 사용자 이름이 이미 존재할 경우 발생하는 예외
+     */
     public User registerUser(User user) {
         if (userRepository.existsByUsername(user.getUsername())) {
             throw new IllegalArgumentException("Username is already taken");
@@ -33,12 +45,23 @@ public class UserService {
         return savedUser;
     }
 
+    /**
+     * 사용자에게 이메일 인증을 보내는 메서드
+     *
+     * @param user 이메일 인증을 보낼 사용자 객체
+     */
     private void sendVerificationEmail(User user) {
         String email = user.getEmail();
         String verificationLink = "http://localhost:8080/verify-email?email=" + email;
         emailService.sendVerificationEmail(email, verificationLink);
     }
 
+    /**
+     * 사용자 이름으로 사용자를 조회하는 메서드
+     *
+     * @param username 조회할 사용자 이름
+     * @return 조회된 사용자 객체
+     */
     public User findByUsername(String username) {
         return userRepository.findByUsername(username);
     }


### PR DESCRIPTION
## 주요 변경 사항

### 1. StrictMode 제거
- 개발 중 콘솔 경고를 줄이고 디버깅을 용이하게 하기 위해 StrictMode 제거.

### 2. 채팅 초기화 및 채팅방 ID 관리 기능 추가
- `useCallback` 훅을 사용하여 `initChat` 함수 추가
  - 채팅 초기화 시 MBTI와 새로운 `chatRoomId`로 초기화
  - Claude의 초기 응답을 설정하여 메시지에 추가
  - 초기화된 상태를 추적하는 `isInitialized` 상태 추가
- `useState` 훅을 사용하여 `chatRoomId` 상태 추가
  - 새로운 채팅방 ID를 생성하여 관리
- `sendMessage` 함수에 `chatRoomId`를 매개변수로 전달하여 채팅방 별 메시지 관리
- `ChatBox` 컴포넌트에 `chatRoomId` prop 추가
- `useEffect`를 통해 컴포넌트 로드 시 `initChat` 함수 호출
- 기존 `useEffect` 훅 내에서 채팅 페이지 로드 시 상태 로그 출력 유지

### 3. 백엔드 채팅 초기화 및 채팅방 ID 관리 기능 추가
- `askClaude` 메서드 수정:
  - `UserMessage` 객체에서 `chatRoomId`를 받아오도록 수정
  - 사용자 메시지와 Claude 응답을 DB에 저장 시 `chatRoomId` 사용
- 새로운 `initializeChat` 메서드 추가:
  - `UserMessage` 객체에서 `chatRoomId`를 받아와 초기화 시 사용
  - MBTI와 채팅방 ID를 기반으로 Claude 채팅 초기화
  - 초기화된 채팅방 상태를 `chatService`에 저장하여 중복 초기화 방지
  - 초기화 성공 시 Claude의 초기 응답을 반환
- `updateContext` 메서드:
  - 사용자 메시지와 AI 응답을 분석하여 컨텍스트 업데이트
  - 예: 특정 키워드를 포함한 메시지로부터 선호도 정보 추출

### 4. 채팅 초기화 상태 관리 기능 추가
- `initializedChats` 맵 추가:
  - 각 채팅방의 초기화 상태를 저장
  - 채팅방 ID와 초기화 상태를 매핑하여 관리
- `isInitialized` 메서드 추가:
  - 주어진 채팅방 ID의 초기화 상태를 반환
  - 초기화되지 않은 채팅방은 기본적으로 `false` 반환
- `setInitialized` 메서드 추가:
  - 주어진 채팅방 ID의 초기화 상태를 설정
- 기존 기능 유지 및 컨텍스트 관리 메서드 추가:
  - `addContext`, `getContext`, `getFullContext` 메서드를 통해 채팅 컨텍스트 관리
  - 사용자 요청 및 Claude 응답 저장 로직 유지

### 5. ClaudeApiService에 채팅 초기화 기능 추가 및 컨텍스트 제거
- 고정 프롬프트에 '상대방이 욕설이나 선정적인 문구를 사용할 경우 대화를 종료' 항목 추가
- 기존 컨텍스트 기능 제거 및 코드 정리
- ClaudeResponse 파싱 로직 개선 및 예외 처리 추가
- Claude API 초기화 요청 기능 추가 (`initializeClaudeChat` 메서드)
- JSON 문자열 안전화 로직 (`sanitizeJsonString` 메서드) 개선
- 민감 정보 마스킹 기능 추가 (`maskSensitiveInfo` 메서드)

### 6. 프론트엔드 API 서비스 업데이트
- `sendMessage` 함수에서 컨텍스트 대신 `chatRoomId` 사용
- 새로운 채팅방 초기화를 위한 `initializeChat` 함수 추가
- API 호출 시 `chatRoomId`를 포함하여 메시지 전송
- 콘솔 로그로 디버깅 정보 출력 (메시지, MBTI, chatRoomId)
